### PR TITLE
Make the API coherant again

### DIFF
--- a/include/CANFrame.h
+++ b/include/CANFrame.h
@@ -13,17 +13,7 @@
  */
 class CANFrame {
 public:
-  struct IDKey {
-    std::string str_key;
-    unsigned long long int_key;
-  };
-
-  struct IntIDKeyCompare {
-    bool operator()(const IDKey& k1, const IDKey& k2) const;
-  };
-
-
-  using container_type = std::map<IDKey, CANSignal, IntIDKeyCompare>;
+  using container_type = std::map<std::string, CANSignal>;
   using iterator = container_type::iterator;
   using const_iterator = container_type::const_iterator;
   using reverse_iterator = container_type::reverse_iterator;
@@ -119,11 +109,6 @@ public:
   void addSignal(const CANSignal& signal);
 
   /**
-   * @brief Removes the signal with the given start bit 
-   */
-  void removeSignal(unsigned int start_bit);
-
-  /**
    * @brief Removes the signal associated with the given name
    */
   void removeSignal(const std::string& name);
@@ -159,8 +144,6 @@ private:
   std::string comment_;
   
   container_type map_;
-  std::map<unsigned, IDKey> intKeyIdx_; // Index by start bit
-  std::map<std::string, IDKey> strKeyIdx_; // Index by name
 };
 
 #endif

--- a/include/CANFrame.h
+++ b/include/CANFrame.h
@@ -13,8 +13,17 @@
  */
 class CANFrame {
 public:
-  using container_type = std::map<unsigned int, std::shared_ptr<CANSignal>>;
-  using str_container_type = std::map<std::string, std::shared_ptr<CANSignal>>;
+  struct IDKey {
+    std::string str_key;
+    unsigned long long int_key;
+  };
+
+  struct IntIDKeyCompare {
+    bool operator()(const IDKey& k1, const IDKey& k2) const;
+  };
+
+
+  using container_type = std::map<IDKey, CANSignal, IntIDKeyCompare>;
   using iterator = container_type::iterator;
   using const_iterator = container_type::const_iterator;
   using reverse_iterator = container_type::reverse_iterator;
@@ -31,12 +40,13 @@ public:
    * @param dlc DLC of the frame
    * @param comment Optional comment for the frame
    */
-  CANFrame(const std::string& name, unsigned long long can_id, unsigned int dlc, unsigned int period = 0, const std::string& comment = "");
+  CANFrame(const std::string& name, unsigned long long can_id, unsigned int dlc, 
+           unsigned int period = 0, const std::string& comment = "");
 
-  CANFrame(const CANFrame&);
-  CANFrame& operator=(CANFrame);
-  CANFrame(CANFrame&&);
-  CANFrame& operator=(CANFrame&&);
+  CANFrame(const CANFrame&) = default;
+  CANFrame& operator=(const CANFrame&) = default;
+  CANFrame(CANFrame&&) = default;
+  CANFrame& operator=(CANFrame&&) = default;
 
 public:
   /**
@@ -77,26 +87,26 @@ public:
 
 public:
   /**
-   * @brief Fetches the signal with the given start bit.
+   * @brief Fetches the signal with the given name.
    * @see at
    */
-  std::shared_ptr<CANSignal> operator[](unsigned int start_bit) const;
-
+  const CANSignal& operator[](const std::string& name) const;
+  
   /**
    * @brief Fetches the signal with the given name.
    * @see at
    */
-  std::shared_ptr<CANSignal> operator[](const std::string& name) const;
+  CANSignal& operator[](const std::string& name);
 
   /**
    * @brief Fetches the signal with the given name.
    */
-  std::shared_ptr<CANSignal> at(const std::string& name) const;
-
+  const CANSignal& at(const std::string& name) const;
+  
   /**
-   * @brief Fetches the signal with the given start bit.
+   * @brief Fetches the signal with the given name.
    */
-  std::shared_ptr<CANSignal> at(unsigned int start_bit) const;
+  CANSignal& at(const std::string& name);
   
   /**
    * @return true if a signal with the given name is already registered with the current frame.
@@ -104,14 +114,9 @@ public:
   bool contains(const std::string& name) const;
 
   /**
-   * @return true if a signal with the given start bit is already registered with the current frame.
-   */
-  bool contains(unsigned int start_bit) const;
-
-  /**
    * @brief Registers the given signal with the frame.
    */
-  void addSignal(std::shared_ptr<CANSignal> signal);
+  void addSignal(const CANSignal& signal);
 
   /**
    * @brief Removes the signal with the given start bit 
@@ -151,9 +156,11 @@ private:
   unsigned long long can_id_;
   unsigned int dlc_;
   unsigned int period_;
-  std::map<unsigned int, std::shared_ptr<CANSignal>> intIndex_; // Index by start bit
-  std::map<std::string, std::shared_ptr<CANSignal>> strIndex_; // Index by name
   std::string comment_;
+  
+  container_type map_;
+  std::map<unsigned, IDKey> intKeyIdx_; // Index by start bit
+  std::map<std::string, IDKey> strKeyIdx_; // Index by name
 };
 
 #endif

--- a/src/analysis/CANFrameAnalysis.cpp
+++ b/src/analysis/CANFrameAnalysis.cpp
@@ -75,7 +75,7 @@ std::vector<SignalLayoutEntry> compute_layout(const CANFrame& src) {
     std::vector<SignalLayoutEntry> result;
 
     for(const auto& signal: src) {
-        const CANSignal& sig = *signal.second; 
+        const CANSignal& sig = signal.second; 
         int lr_start_bit, lr_end_bit;
 
         if(sig.endianness() == CANSignal::BigEndian) {

--- a/utils/can-parse/check-frame.cpp
+++ b/utils/can-parse/check-frame.cpp
@@ -6,8 +6,8 @@
 void CppCAN::can_parse::check_all_frames(CANDatabase& db) {
   std::vector<uint32_t> ids;
     for(const auto& frame : db) {
-      if(!CppCAN::analysis::is_frame_layout_ok(*frame.second))
-        ids.push_back(frame.second->can_id());
+      if(!CppCAN::analysis::is_frame_layout_ok(frame.second))
+        ids.push_back(frame.second.can_id());
     }
 
     if(ids.size() == 0)

--- a/utils/can-parse/print-frame.cpp
+++ b/utils/can-parse/print-frame.cpp
@@ -78,8 +78,8 @@ void CppCAN::can_parse::print_all_frames(CANDatabase& db) {
   // First, explore the database to find "pretty-printing" parameters
   int frame_name_maxsize = 12; // At least a reasonable column size
   for(const auto& frame : db) {
-    if(frame.second->name().size() > frame_name_maxsize)
-      frame_name_maxsize = frame.second->name().size() + 1;
+    if(frame.second.name().size() > frame_name_maxsize)
+      frame_name_maxsize = frame.second.name().size() + 1;
   }
 
   int full_line_size = frame_name_maxsize + INT_COL_SIZE * 3; 
@@ -93,7 +93,7 @@ void CppCAN::can_parse::print_all_frames(CANDatabase& db) {
   std::cout.fill(' ');
              
   for(const auto& frame : db) {
-    print_frame_line(*frame.second, frame_name_maxsize);
+    print_frame_line(frame.second, frame_name_maxsize);
   }
   
   /*


### PR DESCRIPTION
As an exercise, I tried to use `std::shared_ptr` everywhere to see how it would work out. It was actually relevant in the `CANDatabase` instances because I wanted to give two indexes for the `CANFrame` (the frame name and frame's CAN ID).

Well, I felt like it wasn't working after all (iterating through the frames and the signals): the user was having more work to do while gaining no benefit. So I removed the `std::shared_ptr` :wink:. 

* Keys for the frames: name and CAN ID
* Keys for the signals: name

More work on the API could be done, but i'll stop here for now. 