### PR TITLE
Added the PrintOne functionnality

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,5 +24,6 @@ target_include_directories(cpp_can_parser
 add_executable(can-parse 
 	utils/can-parse/can-parse.cpp
 	utils/can-parse/print-frame.cpp
+	utils/can-parse/print-single-frame.cpp
 	utils/can-parse/check-frame.cpp)
 target_link_libraries(can-parse cpp_can_parser)

--- a/utils/can-parse/can-parse.cpp
+++ b/utils/can-parse/can-parse.cpp
@@ -77,7 +77,13 @@ std::tuple<CanParseAction, std::string, uint32_t> extractAction(int argc, char**
       check_args = false;
       
       try {
-        detail_frame = std::stoul(arg);
+        if(arg.compare(0, 2, "0x") == 0 || arg.compare(0, 2, "0X") == 0) {
+          detail_frame = std::stoul(arg, nullptr, 16);
+        }
+        else {
+          detail_frame = std::stoul(arg);
+        }
+        
         action = static_cast<CanParseAction>(static_cast<int>(action) + 1);
         continue;
       } catch(const std::logic_error& e) {
@@ -135,6 +141,19 @@ int main(int argc, char** argv) {
       print_all_frames(db);
       break;
 
+    case PrintOne:
+    {
+      try {
+        print_single_frame(db, detail_frame);
+      }
+      catch(const std::out_of_range&) {
+        std::cerr << "Cannot find the frame with ID " << std::hex << std::showbase
+                  << detail_frame << std::endl;
+        return 3; 
+      }
+    }
+    break;
+      
     case CheckAll:
       check_all_frames(db);
       break;

--- a/utils/can-parse/operations.h
+++ b/utils/can-parse/operations.h
@@ -10,14 +10,9 @@ class CANDatabase;
 namespace CppCAN {
 namespace can_parse {
     /**
-     * @brief Prints a single frame selected by its frame name
-    void printSingleFrame(CANDatabase& db, const std::string& frame_name);
-     */
-    
-    /**
      * @brief Prints a single frame selected by its CAN ID.
-    void printSingleFrame(CANDatabase& db, uint64_t can_id);
      */
+    void print_single_frame(CANDatabase& db, uint32_t can_id);
 
     /**
      * @brief Prints all the frames of the database

--- a/utils/can-parse/print-frame.cpp
+++ b/utils/can-parse/print-frame.cpp
@@ -9,60 +9,6 @@
  */
 static const int INT_COL_SIZE = 10;
 
-void print_info_separator(int level = 0) {
-  static const char* level_0_separator = "##############";
-  static const char* level_1_separator = "--------------";
-  static const char* level_2_separator = "~~~~~~~~~~~~~~";
-  const char** separator = nullptr;
-
-  switch(level) {
-    case 0:
-    default:
-      separator = &level_0_separator;
-      break;
-
-    case 1:
-      separator = &level_1_separator;
-      break;
-  }
-    std::cout << *separator << std::endl;
-}
-
-void print_frame_impl(const CANFrame& frame, unsigned name_col_size) {   
-  std::cout << std::left << std::setw(name_col_size) << frame.name() << ":\t"  
-            << std::hex << std::showbase << frame.can_id() << "/" 
-            << std::dec << std::noshowbase << frame.dlc() << "/"
-            << frame.period() << "s" << std::endl;
-
-  if(frame.comment().size() > 0) {
-    std::cout << "COMMENT" << frame.name() << ":\t \"" << frame.comment() << "\"" << std::endl;
-  }
-}
-
-void print_signal_impl(const CANSignal& sig) {
-  std::cout << "SIGNAL[" << sig.name() << "]: " << std::endl;
-  std::cout << "\tstart bit:\t" << sig.start_bit() << std::endl;
-  std::cout << "\tlength:\t\t" << sig.length() << std::endl;
-  std::cout << "\tendianness:\t\t" << ((sig.endianness() == CANSignal::BigEndian) 
-                                      ? "BigEndian" : "LittleEndian") << std::endl;
-  std::cout << "\tsignedness:\t\t" << ((sig.signedness() == CANSignal::Signed) 
-                                      ? "Signed" : "Unsigned") << std::endl;
-  std::cout << "\tscale:\t" << sig.scale() << std::endl;
-  std::cout << "\toffset:\t" << sig.offset() << std::endl;
-  std::cout << "\trange:\t" << sig.range().min << " -> " << sig.range().max << std::endl;
-
-
-  if(sig.choices().size() > 0) {
-    std::cout << "\tchoices:" << std::endl;
-    
-    for(const auto& choice: sig.choices()) {
-      std::string result = "";
-      result += std::to_string(choice.first) + " -> \"" + choice.second + "\", ";
-      std::cout << "\t\t" << result << std::endl;
-    }
-  }
-}
-
 void print_frame_line(const CANFrame& src, int name_col_size) {
   std::cout << std::left
             << std::setw(name_col_size) << src.name() 
@@ -95,22 +41,4 @@ void CppCAN::can_parse::print_all_frames(CANDatabase& db) {
   for(const auto& frame : db) {
     print_frame_line(frame.second, frame_name_maxsize);
   }
-  
-  /*
-  for(const auto& frame : db) {
-    print_frame_impl(*frame.second, frame_name_maxsize);
-    print_info_separator(1);
-    
-    size_t j = 0;
-    for(const auto& sig : *frame.second) {
-      print_signal_impl(*sig.second);
-
-      if(j++ < frame.second->size() - 1)
-        print_info_separator(2);
-    }
-    
-    if(i++ < db.size() - 1)
-      print_info_separator();
-  }
-  */
 }

--- a/utils/can-parse/print-single-frame.cpp
+++ b/utils/can-parse/print-single-frame.cpp
@@ -1,0 +1,118 @@
+#include "operations.h"
+#include "CANDatabase.h"
+#include <iostream>
+#include <iomanip>
+
+
+// The following helper classes have been taken from
+// https://stackoverflow.com/a/14861289/8147455
+template<typename charT, typename traits = std::char_traits<charT> >
+class center_helper {
+    std::basic_string<charT, traits> str_;
+public:
+    center_helper(std::basic_string<charT, traits> str) : str_(str) {}
+    template<typename a, typename b>
+    friend std::basic_ostream<a, b>& operator<<(std::basic_ostream<a, b>& s, const center_helper<a, b>& c);
+};
+
+template<typename charT, typename traits = std::char_traits<charT> >
+center_helper<charT, traits> centered(std::basic_string<charT, traits> str) {
+    return center_helper<charT, traits>(str);
+}
+
+// redeclare for std::string directly so we can support anything that implicitly converts to std::string
+center_helper<std::string::value_type, std::string::traits_type> centered(const std::string& str) {
+    return center_helper<std::string::value_type, std::string::traits_type>(str);
+}
+
+template<typename charT, typename traits>
+std::basic_ostream<charT, traits>& operator<<(std::basic_ostream<charT, traits>& s, const center_helper<charT, traits>& c) {
+    std::streamsize w = s.width();
+    if (w > c.str_.length()) {
+        std::streamsize left = (w + c.str_.length()) / 2;
+        s.width(left);
+        s << c.str_;
+        s.width(w - left);
+        s << "";
+    } else {
+        s << c.str_;
+    }
+    return s;
+}
+
+void print_info_separator(int level = 0) {
+  static const char* level_0_separator = "##############";
+  static const char* level_1_separator = "--------------";
+  static const char* level_2_separator = "~~~~~~~~~~~~~~";
+  const char** separator = nullptr;
+
+  switch(level) {
+    case 0:
+    default:
+      separator = &level_0_separator;
+      break;
+
+    case 1:
+      separator = &level_1_separator;
+      break;
+  }
+    std::cout << *separator << std::endl;
+}
+
+void print_frame_impl(const CANFrame& frame) {   
+  std::cout << frame.name() << ":\t"  
+            << std::hex << std::showbase << frame.can_id() << "/" 
+            << std::dec << std::noshowbase << frame.dlc() << "/"
+            << frame.period() << "ms" << std::endl;
+
+  if(frame.comment().size() > 0) {
+    std::cout << "COMMENT" << frame.name() << ":\t \"" << frame.comment() << "\"" << std::endl;
+  }
+}
+
+void print_signal_impl(const CANSignal& sig) {
+  std::cout << "SIGNAL[" << sig.name() << "]: " << std::endl;
+  std::cout << "\tstart bit:\t" << sig.start_bit() << std::endl;
+  std::cout << "\tlength:\t\t" << sig.length() << std::endl;
+  std::cout << "\tendianness:\t\t" << ((sig.endianness() == CANSignal::BigEndian) 
+                                      ? "BigEndian" : "LittleEndian") << std::endl;
+  std::cout << "\tsignedness:\t\t" << ((sig.signedness() == CANSignal::Signed) 
+                                      ? "Signed" : "Unsigned") << std::endl;
+  std::cout << "\tscale:\t" << sig.scale() << std::endl;
+  std::cout << "\toffset:\t" << sig.offset() << std::endl;
+  std::cout << "\trange:\t" << sig.range().min << " -> " << sig.range().max << std::endl;
+
+
+  if(sig.choices().size() > 0) {
+    std::cout << "\tchoices:" << std::endl;
+    
+    for(const auto& choice: sig.choices()) {
+      std::string result = "";
+      result += std::to_string(choice.first) + " -> \"" + choice.second + "\", ";
+      std::cout << "\t\t" << result << std::endl;
+    }
+  }
+}
+
+void CppCAN::can_parse::print_single_frame(CANDatabase& db, uint32_t can_id) {
+  const CANFrame& frame = db[can_id];
+
+  print_frame_impl(frame);
+  
+  /*
+  for(const auto& frame : db) {
+    print_info_separator(1);
+    
+    size_t j = 0;
+    for(const auto& sig : *frame.second) {
+      print_signal_impl(*sig.second);
+
+      if(j++ < frame.second->size() - 1)
+        print_info_separator(2);
+    }
+    
+    if(i++ < db.size() - 1)
+      print_info_separator();
+  }
+  */
+}


### PR DESCRIPTION
This pull request introduced the "PrintOne" functionnality, ie. get a detailed report on a single frame.

The detailed report includes:
* Frame name
* CAN ID
* DLC
* Period
* Signals presented in a table
  * Name
  * Length
  * Start bit
  * Scale
  * Offset
  * Endianness
  * Signedness
  * Range
  * Enumeration (if any)

I have got a very good time implementing this, but it's sure that it has been fastidious. The result is very pretty in the end, at least in my opinion :stuck_out_tongue: 